### PR TITLE
Add GUI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project provides a small command line utility for sending personalized emai
 - Optional send scheduling with configurable delays
 - Supports multiple Outlook accounts
 - Simple CLI interface powered by [Typer](https://typer.tiangolo.com)
+- Optional Tkinter GUI for quick campaigns
 
 ## Requirements
 
@@ -63,6 +64,17 @@ python send_emails.py run --subject "Subject line" \
 ```
 
 Use `--help` for a complete list of options. For testing you can add `--dry-run` to render mails without sending them.
+
+### GUI Application
+
+For a more user-friendly option run the Tkinter based GUI:
+
+```bash
+python send_emails_gui.py
+```
+
+The GUI lets you browse for the leads Excel file, fill in the campaign details
+and start sending in one click while showing live log output.
 
 ## Example Templates
 

--- a/send_emails_gui.py
+++ b/send_emails_gui.py
@@ -1,0 +1,81 @@
+import threading
+import logging
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+from mailer import send_campaign
+
+log = logging.getLogger('gui')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+
+class TextHandler(logging.Handler):
+    def __init__(self, text_widget):
+        super().__init__()
+        self.text_widget = text_widget
+    def emit(self, record):
+        msg = self.format(record)
+        self.text_widget.after(0, self.text_widget.insert, tk.END, msg + '\n')
+        self.text_widget.after(0, self.text_widget.see, tk.END)
+
+def run_campaign(opts):
+    try:
+        send_campaign(**opts)
+    except Exception as e:
+        log.exception('Campaign error: %s', e)
+
+def start_send(entries, dry_var):
+    opts = {
+        'subject_line': entries['subject'].get(),
+        'excel_path': entries['leads'].get() or None,
+        'template_base': entries['template_base'].get() or None,
+        'sheet_name': entries['sheet'].get() or None,
+        'send_at': entries['send_at'].get() or 'now',
+        'account': entries['account'].get() or None,
+        'language_column': entries['language_column'].get() or 'language',
+        'dry_run': bool(dry_var.get()),
+    }
+    threading.Thread(target=run_campaign, args=(opts,), daemon=True).start()
+
+def browse_file(entry):
+    path = filedialog.askopenfilename(title='Select Excel file', filetypes=[('Excel','*.xlsx *.xls')])
+    if path:
+        entry.delete(0, tk.END)
+        entry.insert(0, path)
+
+def main():
+    root = tk.Tk()
+    root.title('Outspamer GUI')
+
+    fields = [
+        ('Subject', 'subject'),
+        ('Leads file', 'leads'),
+        ('Template base', 'template_base'),
+        ('Sheet name', 'sheet'),
+        ('Send at', 'send_at'),
+        ('Account', 'account'),
+        ('Language column', 'language_column'),
+    ]
+    entries = {}
+    for idx, (label, key) in enumerate(fields):
+        tk.Label(root, text=label).grid(row=idx, column=0, sticky='e', padx=5, pady=2)
+        ent = tk.Entry(root, width=40)
+        ent.grid(row=idx, column=1, sticky='w', padx=5, pady=2)
+        entries[key] = ent
+        if key == 'leads':
+            btn = tk.Button(root, text='Browse', command=lambda e=ent: browse_file(e))
+            btn.grid(row=idx, column=2, padx=5)
+
+    dry_var = tk.IntVar(value=0)
+    tk.Checkbutton(root, text='Dry run', variable=dry_var).grid(row=len(fields), column=1, sticky='w', pady=4)
+
+    send_btn = tk.Button(root, text='Send campaign', command=lambda: start_send(entries, dry_var))
+    send_btn.grid(row=len(fields)+1, column=1, pady=4)
+
+    log_text = tk.Text(root, height=15, width=60)
+    log_text.grid(row=len(fields)+2, column=0, columnspan=3, padx=5, pady=5)
+    th = TextHandler(log_text)
+    logging.getLogger().addHandler(th)
+
+    root.mainloop()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a basic Tkinter GUI for sending campaigns
- document the new GUI option in the README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile mailer/*.py send_emails.py send_emails_gui.py`
- `python send_emails.py run --help` *(fails: ModuleNotFoundError: No module named 'pythoncom')*

------
https://chatgpt.com/codex/tasks/task_e_684150d1e1fc8321acee8cd48006a7cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a graphical user interface (GUI) for the email campaign tool, allowing users to easily select files, enter campaign details, and send emails with one click.
  - Real-time log output is now displayed within the GUI for better visibility of campaign progress and errors.

- **Documentation**
  - Updated the README to include instructions and details about the new GUI application and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->