### PR TITLE
Add Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ outspamer run --subject "Subject line" \
 
 Use `--help` for a complete list of options. For testing you can add `--dry-run` to render mails without sending them.
 
+### Web Interface
+
+You can also control the campaign through a small Flask based web app. Run
+
+```bash
+python webapp.py
+```
+
+and open `http://localhost:5000` in your browser. The form lets you upload the
+Excel leads file, pick templates and other options with a more friendly UI.
+
 ## Testing
 
 Run `pytest` to execute the unit tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = {file = "LICENSE"}
 
 [project.scripts]
 outspamer = "send_emails:app"
+outspamer-web = "webapp:app"
 
 [tool.flake8]
 max-line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pywin32; platform_system == "Windows"
 openpyxl
 beautifulsoup4
 pytz
+Flask
 

--- a/templates/webform.html
+++ b/templates/webform.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <title>Outspamer</title>
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <h1 class="mb-4">Outspamer Web Interface</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+    <form method="post" enctype="multipart/form-data" class="card p-4 bg-white shadow-sm">
+      <div class="mb-3">
+        <label class="form-label">Subject</label>
+        <input type="text" name="subject" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Leads Excel file</label>
+        <input type="file" name="leads" class="form-control">
+      </div>
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <label class="form-label">Template base</label>
+          <input type="text" name="template_base" class="form-control" placeholder="email">
+        </div>
+        <div class="col-md-6 mb-3">
+          <label class="form-label">Sheet name</label>
+          <input type="text" name="sheet" class="form-control" placeholder="Sheet1">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <label class="form-label">Send at</label>
+          <input type="text" name="send_at" class="form-control" placeholder="now or 2024-04-01 12:00">
+        </div>
+        <div class="col-md-6 mb-3">
+          <label class="form-label">Account</label>
+          <input type="text" name="account" class="form-control" placeholder="Outlook account">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <label class="form-label">Language column</label>
+          <input type="text" name="language_column" class="form-control" value="language">
+        </div>
+        <div class="col-md-6 mb-3 form-check align-self-end">
+          <input type="checkbox" name="dry_run" class="form-check-input" id="dry_run">
+          <label for="dry_run" class="form-check-label">Dry run</label>
+        </div>
+      </div>
+      <button type="submit" class="btn btn-primary">Send</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,56 @@
+from flask import Flask, render_template, request, redirect, url_for, flash
+from werkzeug.utils import secure_filename
+from mailer import send_campaign
+import os
+import tempfile
+
+app = Flask(__name__)
+app.secret_key = "change-me"
+app.config["UPLOAD_FOLDER"] = tempfile.gettempdir()
+
+ALLOWED_EXTENSIONS = {"xls", "xlsx"}
+
+
+def allowed_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    if request.method == "POST":
+        subject = request.form.get("subject")
+        template_base = request.form.get("template_base") or None
+        sheet = request.form.get("sheet") or None
+        send_at = request.form.get("send_at") or "now"
+        account = request.form.get("account") or None
+        language_column = request.form.get("language_column") or "language"
+        dry_run = bool(request.form.get("dry_run"))
+
+        file = request.files.get("leads")
+        leads_path = None
+        if file and file.filename and allowed_file(file.filename):
+            fname = secure_filename(file.filename)
+            path = os.path.join(app.config["UPLOAD_FOLDER"], fname)
+            file.save(path)
+            leads_path = path
+        try:
+            send_campaign(
+                excel_path=leads_path,
+                subject_line=subject,
+                template_base=template_base,
+                sheet_name=sheet,
+                send_at=send_at,
+                account=account,
+                language_column=language_column,
+                dry_run=dry_run,
+            )
+            flash("Campaign executed successfully!", "success")
+        except Exception as e:
+            flash(f"Error: {e}", "danger")
+        return redirect(url_for("index"))
+
+    return render_template("webform.html")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a minimal Flask app exposing a form to send campaigns
- include Bootstrap-based template for the UI
- document how to start the web interface
- add Flask dependency
- expose an `outspamer-web` console script in `pyproject.toml`
- clean up spacing in `webapp.py`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68422f848fbc83219b1baf9086406619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a web interface for managing email campaigns, allowing users to upload Excel files, select templates, and configure campaign options through a user-friendly form.
- **Documentation**
  - Updated usage instructions in the README to include details on running and accessing the new web interface.
- **Chores**
  - Added Flask as a required dependency and included a new script entry for launching the web interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->