### PR TITLE
Fix scheduling logic with timedelta

### DIFF
--- a/mailer/outlook.py
+++ b/mailer/outlook.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 import pythoncom
 import win32com.client as win32
-from datetime import datetime
+from datetime import datetime, timedelta
 
 log = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ def send_with_outlook(
         return
 
     # Schedule deferred time
-    schedule_time = send_time + (index * delay_seconds)
+    schedule_time = send_time + timedelta(seconds=index * delay_seconds)
     # Outlook expects naive local datetime
     mail.DeferredDeliveryTime = schedule_time
     mail.Send()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from datetime import datetime, timedelta
+
+
+# ensure project root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# stub windows specific modules
+sys.modules.setdefault("pythoncom", types.ModuleType("pythoncom"))
+sys.modules.setdefault("win32com", types.ModuleType("win32com"))
+sys.modules.setdefault("win32com.client", types.ModuleType("client"))
+
+
+def test_send_with_outlook_schedules(monkeypatch, tmp_path):
+    import mailer.outlook as outlook
+
+    send_time = datetime(2023, 1, 1, 12, 0, 0)
+
+    class FakeMail:
+        def __init__(self):
+            self.DeferredDeliveryTime = None
+            self.Attachments = types.SimpleNamespace(Add=lambda path: None)
+
+        def Send(self):
+            pass
+
+    fake_mail = FakeMail()
+
+    class FakeOutlook:
+        def __init__(self):
+            self.Session = types.SimpleNamespace(Accounts=[])
+
+        def CreateItem(self, _):
+            return fake_mail
+
+    monkeypatch.setattr(
+        sys.modules["pythoncom"], "CoInitialize", lambda: None, raising=False
+    )
+    monkeypatch.setattr(
+        sys.modules["win32com.client"],
+        "Dispatch",
+        lambda *a, **k: FakeOutlook(),
+        raising=False,
+    )
+
+    outlook.send_with_outlook(
+        row={"email": "a@example.com"},
+        html_body="<p>test</p>",
+        subject="subj",
+        attachments_dir=str(tmp_path),
+        send_time=send_time,
+        delay_seconds=5,
+        index=2,
+        dry_run=False,
+        send_now_mode=False,
+    )
+
+    assert fake_mail.DeferredDeliveryTime == send_time + timedelta(seconds=10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,6 +58,8 @@ def test_send_campaign_calls_outlook(monkeypatch, tmp_path):
     (tpl_dir / "email.html").write_text("hello {{ salutation }}")
     monkeypatch.setitem(mailer.cfg["paths"], "templates", str(tpl_dir))
 
+    monkeypatch.setitem(mailer.cfg["defaults"], "template_base", "email")
+
     monkeypatch.setitem(mailer.cfg["defaults"], "subject_line", "Default")
 
     send_campaign(excel_path=str(xls), subject_line=None, dry_run=True)


### PR DESCRIPTION
## Summary
- import `timedelta` in `mailer/outlook`
- use `timedelta` when computing scheduled send times
- ensure tests use correct default template name
- add a new test verifying the scheduled time

## Testing
- `pytest -q`
- `flake8` *(fails: blank line contains whitespace, indentation issues, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842a00d15d08321b7511a71bf072af4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduling accuracy for deferred email sending to ensure correct handling of time delays.

- **Tests**
  - Added a new test to verify correct scheduling of deferred email delivery.
  - Updated an existing test to set a required configuration value for template selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->