### PR TITLE
Add Postmark client and default provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,11 @@ __pycache__/
 .mypy_cache/
 .pytest_cache/
 attachments/
-templates/
+templates/*
+!templates/email_de.html
+!templates/email_en.html
+!templates/email_fr.html
+!templates/webform.html
 leads/*.xlsx
 archive/
 # packages

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This project provides a small command line utility for sending personalized emai
 - Python 3.11 or newer
 - Microsoft Outlook on Windows if using the Outlook provider
 - Postmark server token via the `POSTMARK_TOKEN` environment variable or
-  `postmark_token` setting
+  `postmark_token` setting. These variables can also be defined in a `.env`
+  file at the project root.
 - See `requirements.txt` for Python package dependencies
 
 ## Installation
@@ -45,7 +46,7 @@ This project provides a small command line utility for sending personalized emai
 
 ## Configuration
 
-The application reads basic paths and defaults from `settings.toml`. You can adjust directories for attachments, templates and leads as well as the default delay between mails. Environment variables with the same names can override the TOML settings.
+The application reads basic paths and defaults from `settings.toml`. You can adjust directories for attachments, templates and leads as well as the default delay between mails. Environment variables with the same names can override the TOML settings. A `.env` file in the project root is loaded automatically so you can place variables like `POSTMARK_TOKEN` there.
 The bundled `sample_leads.xlsx` file contains **fictitious** contact details for testing only.
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Outspamer
 
-This project provides a small command line utility for sending personalized email campaigns using Microsoft Outlook. Leads are loaded from an Excel spreadsheet and merged into Jinja2-based HTML templates. Mails can be scheduled or sent immediately and optional attachments are automatically added from the configured folder.
+This project provides a small command line utility for sending personalized email campaigns. It supports Microsoft Outlook as well as Postmark. Leads are loaded from an Excel spreadsheet and merged into Jinja2-based HTML templates. Mails can be scheduled or sent immediately and optional attachments are automatically added from the configured folder.
 
 **Important:** This code is intended for controlled outreach and testing. Make sure that any usage complies with local regulations and the terms of your email provider.
 
@@ -9,13 +9,16 @@ This project provides a small command line utility for sending personalized emai
 - Reads contact data from an Excel sheet
 - Language-specific templates using Jinja2
 - Optional send scheduling with configurable delays
+- Pluggable provider (Outlook or Postmark)
 - Supports multiple Outlook accounts
 - Simple CLI interface powered by [Typer](https://typer.tiangolo.com)
 
 ## Requirements
 
 - Python 3.11 or newer
-- Microsoft Outlook installed on Windows (for the COM interface)
+- Microsoft Outlook on Windows if using the Outlook provider
+- Postmark server token via the `POSTMARK_TOKEN` environment variable or
+  `postmark_token` setting
 - See `requirements.txt` for Python package dependencies
 
 ## Installation
@@ -61,13 +64,16 @@ account           = ""
 template_column   = "template"
 language_column   = "language"
 cc_column         = "cc"
+provider          = "postmark"
+postmark_token    = ""
 ```
 
-The optional `account` field selects a specific Outlook account by display name
-or SMTP address. `template_column` allows specifying per-row template names. If
-absent, the template is built from `template_base` and the value in
-`language_column`. `cc_column` can hold additional recipients; if omitted,
-addresses separated by semicolons in the `email` column will be used.
+`provider` selects the mail backend: `outlook` or `postmark`. The optional
+`account` field is used as the Outlook account name or as the `From` address for
+Postmark. `template_column` allows specifying per-row template names. If absent,
+the template is built from `template_base` and the value in `language_column`.
+`cc_column` can hold additional recipients; if omitted, addresses separated by
+semicolons in the `email` column will be used.
 
 
 ## Usage

--- a/mailer/__init__.py
+++ b/mailer/__init__.py
@@ -11,11 +11,19 @@ from zoneinfo import ZoneInfo
 
 from .settings import Config, load
 from .outlook import send_with_outlook
+from .postmark import send_with_postmark
 from .template_utils import process_template_file, extract_subject_and_body
 from .utils import normalize_columns, resolve_leads_path, extract_subject
 
 log = logging.getLogger(__name__)
 cfg: Config = load()
+
+
+def send_email(provider: str, token: str | None = None, **kwargs) -> None:
+    if provider == "postmark":
+        send_with_postmark(**kwargs, token=token)
+    else:
+        send_with_outlook(**kwargs)
 
 
 def send_campaign(
@@ -192,7 +200,9 @@ def send_campaign(
                     send_time = base_time + timedelta(hours=hour_offset)
                     send_mode = False
 
-                send_with_outlook(
+                send_email(
+                    provider=defaults.provider,
+                    token=defaults.postmark_token,
                     row=row,
                     html_body=html,
                     subject=final_subject,
@@ -233,7 +243,9 @@ def send_campaign(
                     else:
                         base_time = campaign_start
                     send_time = base_time + timedelta(hours=1)
-                    send_with_outlook(
+                    send_email(
+                        provider=defaults.provider,
+                        token=defaults.postmark_token,
                         row=row,
                         html_body=html,
                         subject=final_subject,

--- a/mailer/postmark.py
+++ b/mailer/postmark.py
@@ -1,0 +1,90 @@
+import os
+import logging
+import pathlib
+import base64
+import mimetypes
+import time
+from datetime import datetime, timedelta
+
+from postmarker.core import PostmarkClient
+
+log = logging.getLogger(__name__)
+
+
+def _collect_attachments(directory: str) -> list[dict]:
+    path = pathlib.Path(directory)
+    if not path.exists():
+        log.warning("Attachments directory '%s' not found", directory)
+        return []
+    items = []
+    for item in path.iterdir():
+        if item.is_file():
+            with item.open("rb") as f:
+                content = base64.b64encode(f.read()).decode()
+            items.append(
+                {
+                    "Name": item.name,
+                    "Content": content,
+                    "ContentType": mimetypes.guess_type(item.name)[0]
+                    or "application/octet-stream",
+                }
+            )
+    return items
+
+
+def send_with_postmark(
+    *,
+    row,
+    html_body: str,
+    subject: str,
+    attachments_dir: str,
+    send_time: datetime | None,
+    delay_seconds: float,
+    index: int,
+    account_name: str | None = None,
+    dry_run: bool = False,
+    send_now_mode: bool = False,
+    cc: str | None = None,
+    token: str | None = None,
+) -> None:
+    """Send a single e-mail using Postmark."""
+    if dry_run:
+        log.info(
+            "DRY-RUN  %s <%s> cc=%s",
+            row.get("vorname", ""),
+            row.get("email", ""),
+            cc or "",
+        )
+        return
+
+    token = token or os.getenv("POSTMARK_TOKEN")
+    if not token:
+        log.error("Postmark token not configured")
+        return
+
+    if send_time is not None and not send_now_mode:
+        schedule = send_time + timedelta(seconds=index * delay_seconds)
+        delta = (schedule - datetime.now()).total_seconds()
+        if delta > 0:
+            time.sleep(delta)
+
+    data = {
+        "From": account_name or os.getenv("POSTMARK_FROM", ""),
+        "To": row["email"],
+        "Subject": subject,
+        "HtmlBody": html_body,
+    }
+    if cc:
+        data["Cc"] = cc
+
+    attachments = _collect_attachments(attachments_dir)
+    if attachments:
+        data["Attachments"] = attachments
+
+    client = PostmarkClient(server_token=token)
+
+    try:
+        client.emails.send(**data)
+        log.info("sent -> %s <%s>", row.get("vorname", ""), row["email"])
+    except Exception as exc:
+        log.error("Postmark send error: %s", exc)

--- a/mailer/settings.py
+++ b/mailer/settings.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import os
 import tomllib
+from dotenv import load_dotenv
 
 ROOT = Path(__file__).resolve().parent.parent
 TOML = ROOT / "settings.toml"
@@ -40,6 +41,7 @@ class Config:
 
 
 def load() -> Config:
+    load_dotenv(ROOT / ".env")
     paths = Paths(
         attachments=str(ROOT / "attachments"),
         templates=str(ROOT / "templates"),

--- a/mailer/settings.py
+++ b/mailer/settings.py
@@ -29,6 +29,8 @@ class Defaults:
     template_column: str = "template"
     language_column: str = "language"
     cc_column: str = "cc"
+    provider: str = "postmark"
+    postmark_token: str = ""
 
 
 @dataclass
@@ -75,6 +77,8 @@ def load() -> Config:
         ("TEMPLATE_COLUMN", "template_column"),
         ("LANGUAGE_COLUMN", "language_column"),
         ("CC_COLUMN", "cc_column"),
+        ("MAIL_PROVIDER", "provider"),
+        ("POSTMARK_TOKEN", "postmark_token"),
     ]:
         if os.getenv(envvar):
             setattr(defaults, attr, os.getenv(envvar))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ openpyxl
 beautifulsoup4
 pytz
 Flask
+postmarker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ beautifulsoup4
 pytz
 Flask
 postmarker
+python-dotenv
 

--- a/settings.toml
+++ b/settings.toml
@@ -16,4 +16,5 @@ cc_column       = "cc"
 cc_threshold   = 3
 subject_line    = "Default Subject Settings"
 provider         = "postmark"
-postmark_token   = ""
+POSTMARK_TOKEN= "04556ca9-25d3-415c-a92d-2142a9abf17b"
+POSTMARK_FROM= "jsb@synsol.ch"

--- a/settings.toml
+++ b/settings.toml
@@ -15,3 +15,5 @@ language_column = "language"
 cc_column       = "cc"
 cc_threshold   = 3
 subject_line    = "Default Subject Settings"
+provider         = "postmark"
+postmark_token   = ""

--- a/templates/email_de.html
+++ b/templates/email_de.html
@@ -1,2 +1,5 @@
 <!DOCTYPE html>
+
 <html><body><p>Hallo {{ salutation }},</p><p>Dies ist die deutsche Version.</p></body></html>
+
+    <!-- processed -->

--- a/templates/email_en.html
+++ b/templates/email_en.html
@@ -1,2 +1,5 @@
 <!DOCTYPE html>
+
 <html><body><p>Hello {{ salutation }},</p><p>This is English version.</p></body></html>
+
+    <!-- processed -->

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,17 +40,17 @@ def test_resolve_leads_path(tmp_path, monkeypatch):
     assert resolve_leads_path(mailer.cfg, "foo.xlsx") == file
 
 
-def test_send_campaign_calls_outlook(monkeypatch, tmp_path):
+def test_send_campaign_calls_send_email(monkeypatch, tmp_path):
     xls = tmp_path / "l.xlsx"
     df = pd.DataFrame({"email": ["test@example.com"], "vorname": ["Foo"]})
     df.to_excel(xls, index=False)
 
     calls = []
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
 
     # create a minimal template expected by send_campaign
@@ -73,10 +73,10 @@ def test_template_subject_overrides(monkeypatch, tmp_path):
 
     captured = {}
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         captured.update(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
     monkeypatch.setattr(mailer.cfg.defaults, "subject_line", "Default")
     monkeypatch.setattr(mailer.cfg.defaults, "template_base", "email")
@@ -103,10 +103,10 @@ def test_cc_threshold(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
     monkeypatch.setattr(mailer.cfg.defaults, "cc_threshold", 3)
 
@@ -146,10 +146,10 @@ def test_personalize_first_only(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
     monkeypatch.setattr(mailer.cfg.defaults, "cc_threshold", 1)
 
@@ -176,10 +176,10 @@ def test_language_fallback(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
 
     tpl_dir = tmp_path / "tpl_fb"
@@ -201,10 +201,10 @@ def test_follow_up_english(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
 
     tpl_dir = tmp_path / "tpl_follow"
@@ -229,10 +229,10 @@ def test_ch_multilang(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_send_with_outlook(**kwargs):
+    def fake_send_email(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr(mailer, "send_with_outlook", fake_send_with_outlook)
+    monkeypatch.setattr(mailer, "send_email", fake_send_email)
     monkeypatch.setattr(mailer.cfg.defaults, "default_leads_file", str(xls))
 
     tpl_dir = tmp_path / "tpl_ch"


### PR DESCRIPTION
## Summary
- switch to the `postmarker` library
- use Postmark as the default provider
- pass `postmark_token` from settings
- document new configuration and requirement

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462e8551fc8321a29ebbabc9099ac2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sending personalized email campaigns using Postmark alongside Microsoft Outlook.
  - Enabled selection of email provider with corresponding configuration options.

- **Documentation**
  - Updated README to include multiple email provider support and configuration details.

- **Chores**
  - Added Postmark and dotenv dependencies.
  - Enhanced configuration files and environment variable loading for provider and token settings.
  - Updated `.gitignore` to track specific email template files.

- **Tests**
  - Refactored tests to use the new unified email sending function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->